### PR TITLE
removed extra imports

### DIFF
--- a/edict_functions.py
+++ b/edict_functions.py
@@ -7,13 +7,11 @@ import imageio
 from PIL import Image
 import torchvision
 import torch.nn.functional as F
-import torch
 import numpy as np
 from PIL import Image
 import matplotlib.pyplot as plt
 import time
 import datetime
-import torch
 import sys
 import os
 from torchvision import datasets


### PR DESCRIPTION
The `edict_functions.py` had three identical imports: `import torch`, I removed two of them.